### PR TITLE
Split meson files

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -12,7 +12,7 @@ configure_file(
   configuration: config_h,
 )
 
-add_global_arguments([
+add_project_arguments([
   '-DHAVE_CONFIG_H',
   '-DDAZZLE_COMPILATION',
 ], language: 'c')

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('libdazzle', 'c',
   version: '0.1.0',
-  meson_version: '>= 0.36.0',
+  meson_version: '>= 0.40.1',
 )
 
 config_h = configuration_data()

--- a/meson.build
+++ b/meson.build
@@ -14,10 +14,11 @@ configure_file(
 
 add_global_arguments([
   '-DHAVE_CONFIG_H',
-  '-I' + meson.build_root(),
-  '-I' + join_paths(meson.source_root(), 'src'),
   '-DDAZZLE_COMPILATION',
 ], language: 'c')
+
+root_inc = include_directories('.')
+src_inc = include_directories('src')
 
 cc = meson.get_compiler('c')
 

--- a/src/actions/meson.build
+++ b/src/actions/meson.build
@@ -1,0 +1,9 @@
+action_headers = [
+  'dzl-child-property-action.h',
+  'dzl-settings-flag-action.h',
+  'dzl-widget-action-group.h',
+]
+
+libdazzle_public_headers += files(action_headers)
+
+install_headers(action_headers, subdir: join_paths(libdazzle_header_subdir, 'actions'))

--- a/src/actions/meson.build
+++ b/src/actions/meson.build
@@ -4,6 +4,13 @@ action_headers = [
   'dzl-widget-action-group.h',
 ]
 
+action_sources = [
+  'dzl-child-property-action.c',
+  'dzl-settings-flag-action.c',
+  'dzl-widget-action-group.c',
+]
+
 libdazzle_public_headers += files(action_headers)
+libdazzle_public_sources += files(action_sources)
 
 install_headers(action_headers, subdir: join_paths(libdazzle_header_subdir, 'actions'))

--- a/src/animation/meson.build
+++ b/src/animation/meson.build
@@ -1,0 +1,8 @@
+animation_headers = [
+  'dzl-animation.h',
+  'dzl-box-theatric.h',
+]
+
+libdazzle_public_headers += files(animation_headers)
+
+install_headers(animation_headers, subdir: join_paths(libdazzle_header_subdir, 'animation'))

--- a/src/animation/meson.build
+++ b/src/animation/meson.build
@@ -3,6 +3,13 @@ animation_headers = [
   'dzl-box-theatric.h',
 ]
 
+animation_sources = [
+  'dzl-animation.c',
+  'dzl-box-theatric.c',
+]
+
 libdazzle_public_headers += files(animation_headers)
+libdazzle_public_sources += files(animation_sources)
+libdazzle_private_sources += files('dzl-frame-source.c')
 
 install_headers(animation_headers, subdir: join_paths(libdazzle_header_subdir, 'animation'))

--- a/src/app/meson.build
+++ b/src/app/meson.build
@@ -1,0 +1,7 @@
+app_headers = [
+  'dzl-application.h',
+]
+
+libdazzle_public_headers += files(app_headers)
+
+install_headers(app_headers, subdir: join_paths(libdazzle_header_subdir, 'app'))

--- a/src/app/meson.build
+++ b/src/app/meson.build
@@ -2,6 +2,11 @@ app_headers = [
   'dzl-application.h',
 ]
 
+app_sources = [
+  'dzl-application.c',
+]
+
 libdazzle_public_headers += files(app_headers)
+libdazzle_public_sources += files(app_sources)
 
 install_headers(app_headers, subdir: join_paths(libdazzle_header_subdir, 'app'))

--- a/src/bindings/meson.build
+++ b/src/bindings/meson.build
@@ -1,0 +1,8 @@
+bindings_headers = [
+  'dzl-binding-group.h',
+  'dzl-signal-group.h',
+]
+
+libdazzle_public_headers += files(bindings_headers)
+
+install_headers(bindings_headers, subdir: join_paths(libdazzle_header_subdir, 'bindings'))

--- a/src/bindings/meson.build
+++ b/src/bindings/meson.build
@@ -3,6 +3,12 @@ bindings_headers = [
   'dzl-signal-group.h',
 ]
 
+bindings_sources = [
+  'dzl-binding-group.c',
+  'dzl-signal-group.c',
+]
+
 libdazzle_public_headers += files(bindings_headers)
+libdazzle_public_sources += files(bindings_sources)
 
 install_headers(bindings_headers, subdir: join_paths(libdazzle_header_subdir, 'bindings'))

--- a/src/cache/meson.build
+++ b/src/cache/meson.build
@@ -1,0 +1,7 @@
+cache_headers = [
+  'dzl-task-cache.h',
+]
+
+libdazzle_public_headers += files(cache_headers)
+
+install_headers(cache_headers, subdir: join_paths(libdazzle_header_subdir, 'cache'))

--- a/src/cache/meson.build
+++ b/src/cache/meson.build
@@ -2,6 +2,11 @@ cache_headers = [
   'dzl-task-cache.h',
 ]
 
+cache_sources = [
+  'dzl-task-cache.c',
+]
+
 libdazzle_public_headers += files(cache_headers)
+libdazzle_public_sources += files(cache_sources)
 
 install_headers(cache_headers, subdir: join_paths(libdazzle_header_subdir, 'cache'))

--- a/src/files/meson.build
+++ b/src/files/meson.build
@@ -3,6 +3,12 @@ files_headers = [
   'dzl-directory-reaper.h',
 ]
 
+files_sources = [
+  'dzl-directory-model.c',
+  'dzl-directory-reaper.c',
+]
+
 libdazzle_public_headers += files(files_headers)
+libdazzle_public_sources += files(files_sources)
 
 install_headers(files_headers, subdir: join_paths(libdazzle_header_subdir, 'files'))

--- a/src/files/meson.build
+++ b/src/files/meson.build
@@ -1,0 +1,8 @@
+files_headers = [
+  'dzl-directory-model.h',
+  'dzl-directory-reaper.h',
+]
+
+libdazzle_public_headers += files(files_headers)
+
+install_headers(files_headers, subdir: join_paths(libdazzle_header_subdir, 'files'))

--- a/src/fuzzy/meson.build
+++ b/src/fuzzy/meson.build
@@ -1,0 +1,10 @@
+fuzzy_headers = [
+  'dzl-fuzzy-index-builder.h',
+  'dzl-fuzzy-index-cursor.h',
+  'dzl-fuzzy-index-match.h',
+  'dzl-fuzzy-index.h',
+]
+
+libdazzle_public_headers += files(fuzzy_headers)
+
+install_headers(fuzzy_headers, subdir: join_paths(libdazzle_header_subdir, 'fuzzy'))

--- a/src/fuzzy/meson.build
+++ b/src/fuzzy/meson.build
@@ -5,6 +5,15 @@ fuzzy_headers = [
   'dzl-fuzzy-index.h',
 ]
 
+fuzzy_sources = [
+  'dzl-fuzzy-index-builder.c',
+  'dzl-fuzzy-index-cursor.c',
+  'dzl-fuzzy-index-match.c',
+  'dzl-fuzzy-index.c',
+]
+
 libdazzle_public_headers += files(fuzzy_headers)
+libdazzle_public_sources += files(fuzzy_sources)
+libdazzle_private_sources += files('dzl-fuzzy-util.c')
 
 install_headers(fuzzy_headers, subdir: join_paths(libdazzle_header_subdir, 'fuzzy'))

--- a/src/menus/meson.build
+++ b/src/menus/meson.build
@@ -1,0 +1,7 @@
+menus_headers = [
+  'dzl-menu-manager.h',
+]
+
+libdazzle_public_headers += files(menus_headers)
+
+install_headers(menus_headers, subdir: join_paths(libdazzle_header_subdir, 'menus'))

--- a/src/menus/meson.build
+++ b/src/menus/meson.build
@@ -2,6 +2,11 @@ menus_headers = [
   'dzl-menu-manager.h',
 ]
 
+menus_sources = [
+  'dzl-menu-manager.c',
+]
+
 libdazzle_public_headers += files(menus_headers)
+libdazzle_public_sources += files(menus_sources)
 
 install_headers(menus_headers, subdir: join_paths(libdazzle_header_subdir, 'menus'))

--- a/src/meson.build
+++ b/src/meson.build
@@ -21,20 +21,21 @@ version_data.set('DZL_MINOR_VERSION', dazzle_version_minor)
 version_data.set('DZL_MICRO_VERSION', dazzle_version_micro)
 version_data.set('DZL_VERSION', meson.project_version())
 
-dzl_version_h = configure_file(
+configure_file(
           input: 'dzl-version.h.in',
          output: 'dzl-version.h',
     install_dir: libdazzle_header_dir,
         install: true,
   configuration: version_data)
 
-libdazzle_generated_headers = [
-  dzl_version_h,
-]
+libdazzle_generated_headers = []
 
-libdazzle_public_headers = [
-  'dazzle.h',
-]
+install_headers('dazzle.h', subdir: libdazzle_header_subdir)
+
+# Filled out in the subdirs
+libdazzle_public_headers = []
+libdazzle_public_sources = []
+libdazzle_private_sources = []
 
 subdir('actions')
 subdir('animation')
@@ -54,139 +55,10 @@ subdir('tree')
 subdir('util')
 subdir('widgets')
 
-libdazzle_public_sources = [
-  'actions/dzl-child-property-action.c',
-  'actions/dzl-settings-flag-action.c',
-  'actions/dzl-widget-action-group.c',
-
-  'animation/dzl-animation.c',
-  'animation/dzl-box-theatric.c',
-
-  'app/dzl-application.c',
-
-  'bindings/dzl-binding-group.c',
-  'bindings/dzl-signal-group.c',
-
-  'cache/dzl-task-cache.c',
-
-  'files/dzl-directory-model.c',
-  'files/dzl-directory-reaper.c',
-
-  'fuzzy/dzl-fuzzy-index-builder.c',
-  'fuzzy/dzl-fuzzy-index-cursor.c',
-  'fuzzy/dzl-fuzzy-index-match.c',
-  'fuzzy/dzl-fuzzy-index.c',
-
-  'menus/dzl-menu-manager.c',
-
-  'panel/dzl-dock-bin-edge.c',
-  'panel/dzl-dock-bin.c',
-  'panel/dzl-dock-item.c',
-  'panel/dzl-dock-manager.c',
-  'panel/dzl-dock-overlay-edge.c',
-  'panel/dzl-dock-overlay.c',
-  'panel/dzl-dock-paned.c',
-  'panel/dzl-dock-revealer.c',
-  'panel/dzl-dock-stack.c',
-  'panel/dzl-dock-transient-grab.c',
-  'panel/dzl-dock-widget.c',
-  'panel/dzl-dock-window.c',
-  'panel/dzl-dock.c',
-  'panel/dzl-tab-strip.c',
-  'panel/dzl-tab.c',
-
-  'settings/dzl-settings-sandwich.c',
-
-  'shortcuts/dzl-shortcut-accel-dialog.c',
-  'shortcuts/dzl-shortcut-chord.c',
-  'shortcuts/dzl-shortcut-context.c',
-  'shortcuts/dzl-shortcut-controller.c',
-  'shortcuts/dzl-shortcut-label.c',
-  'shortcuts/dzl-shortcut-manager.c',
-  'shortcuts/dzl-shortcut-model.c',
-  'shortcuts/dzl-shortcut-theme-editor.c',
-  'shortcuts/dzl-shortcut-theme-load.c',
-  'shortcuts/dzl-shortcut-theme-save.c',
-  'shortcuts/dzl-shortcut-theme.c',
-  'shortcuts/dzl-shortcuts-group.c',
-  'shortcuts/dzl-shortcuts-section.c',
-  'shortcuts/dzl-shortcuts-shortcut.c',
-  'shortcuts/dzl-shortcuts-window.c',
-
-  'statemachine/dzl-state-machine-buildable.c',
-  'statemachine/dzl-state-machine.c',
-
-  'suggestions/dzl-suggestion-entry-buffer.c',
-  'suggestions/dzl-suggestion-entry.c',
-  'suggestions/dzl-suggestion-popover.c',
-  'suggestions/dzl-suggestion-row.c',
-  'suggestions/dzl-suggestion.c',
-
-  'tree/dzl-tree-builder.c',
-  'tree/dzl-tree.c',
-  'tree/dzl-tree-node.c',
-
-  'util/dzl-cairo.c',
-  'util/dzl-counter.c',
-  'util/dzl-date-time.c',
-  'util/dzl-dnd.c',
-  'util/dzl-file-manager.c',
-  'util/dzl-heap.c',
-  'util/dzl-pango.c',
-  'util/dzl-rgba.c',
-  'util/dzl-util.c',
-
-  'theming/dzl-css-provider.c',
-  'theming/dzl-theme-manager.c',
-
-  'widgets/dzl-bin.c',
-  'widgets/dzl-bolding-label.c',
-  'widgets/dzl-box.c',
-  'widgets/dzl-centering-bin.c',
-  'widgets/dzl-column-layout.c',
-  'widgets/dzl-elastic-bin.c',
-  'widgets/dzl-empty-state.c',
-  'widgets/dzl-entry-box.c',
-  'widgets/dzl-file-chooser-entry.c',
-  'widgets/dzl-list-box.c',
-  'widgets/dzl-multi-paned.c',
-  'widgets/dzl-pill-box.c',
-  'widgets/dzl-priority-box.c',
-  'widgets/dzl-progress-button.c',
-  'widgets/dzl-progress-menu-button.c',
-  'widgets/dzl-progress-icon.c',
-  'widgets/dzl-radio-box.c',
-  'widgets/dzl-scrolled-window.c',
-  'widgets/dzl-search-bar.c',
-  'widgets/dzl-simple-label.c',
-  'widgets/dzl-simple-popover.c',
-  'widgets/dzl-slider.c',
-  'widgets/dzl-stack-list.c',
-  'widgets/dzl-three-grid.c',
-]
-
 libdazzle_sources = [
   libdazzle_generated_headers,
   libdazzle_public_sources,
-
-  'animation/dzl-frame-source.c',
-
-  'fuzzy/dzl-fuzzy-index-private.h',
-  'fuzzy/dzl-fuzzy-util.c',
-  'fuzzy/dzl-fuzzy-util.h',
-
-  'panel/dzl-dock-bin-edge-private.h',
-  'panel/dzl-dock-paned-private.h',
-  'panel/dzl-tab-private.h',
-
-  'shortcuts/dzl-shortcut-closure-chain.c',
-
-  'tree/dzl-tree-private.h',
-
-  'util/dzl-util-private.h',
-
-  'widgets/dzl-rect-helper.c',
-
+  libdazzle_private_sources,
   libdazzle_resources,
 ]
 
@@ -251,17 +123,6 @@ if get_option('with_introspection')
 
   endif
 endif
-
-# TODO: This is ugly and should be handled upstream
-#foreach header: libdazzle_public_headers
-#  header_split = header.split('/')
-#  if header_split.length() == 2
-#    header_path = join_paths(libdazzle_header_subdir, header_split[0])
-#    install_headers(header, subdir: header_path)
-#  else
-#    install_headers(header, subdir: libdazzle_header_subdir)
-#  endif
-#endforeach
 
 pkgg = import('pkgconfig')
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -34,115 +34,25 @@ libdazzle_generated_headers = [
 
 libdazzle_public_headers = [
   'dazzle.h',
-
-  'actions/dzl-child-property-action.h',
-  'actions/dzl-settings-flag-action.h',
-  'actions/dzl-widget-action-group.h',
-
-  'animation/dzl-animation.h',
-  'animation/dzl-box-theatric.h',
-
-  'app/dzl-application.h',
-
-  'bindings/dzl-binding-group.h',
-  'bindings/dzl-signal-group.h',
-
-  'cache/dzl-task-cache.h',
-
-  'files/dzl-directory-model.h',
-  'files/dzl-directory-reaper.h',
-
-  'fuzzy/dzl-fuzzy-index-builder.h',
-  'fuzzy/dzl-fuzzy-index-cursor.h',
-  'fuzzy/dzl-fuzzy-index-match.h',
-  'fuzzy/dzl-fuzzy-index.h',
-
-  'menus/dzl-menu-manager.h',
-
-  'panel/dzl-dock-bin-edge.h',
-  'panel/dzl-dock-bin.h',
-  'panel/dzl-dock-item.h',
-  'panel/dzl-dock-manager.h',
-  'panel/dzl-dock-overlay-edge.h',
-  'panel/dzl-dock-overlay.h',
-  'panel/dzl-dock-paned.h',
-  'panel/dzl-dock-revealer.h',
-  'panel/dzl-dock-stack.h',
-  'panel/dzl-dock-transient-grab.h',
-  'panel/dzl-dock-types.h',
-  'panel/dzl-dock-widget.h',
-  'panel/dzl-dock-window.h',
-  'panel/dzl-dock.h',
-  'panel/dzl-tab-strip.h',
-  'panel/dzl-tab.h',
-
-  'settings/dzl-settings-sandwich.h',
-
-  'shortcuts/dzl-shortcut-accel-dialog.h',
-  'shortcuts/dzl-shortcut-chord.h',
-  'shortcuts/dzl-shortcut-context.h',
-  'shortcuts/dzl-shortcut-controller.h',
-  'shortcuts/dzl-shortcut-label.h',
-  'shortcuts/dzl-shortcut-manager.h',
-  'shortcuts/dzl-shortcut-model.h',
-  'shortcuts/dzl-shortcut-theme-editor.h',
-  'shortcuts/dzl-shortcut-theme.h',
-  'shortcuts/dzl-shortcuts-group.h',
-  'shortcuts/dzl-shortcuts-section.h',
-  'shortcuts/dzl-shortcuts-shortcut.h',
-  'shortcuts/dzl-shortcuts-window.h',
-
-  'statemachine/dzl-state-machine-buildable.h',
-  'statemachine/dzl-state-machine.h',
-
-  'suggestions/dzl-suggestion-entry-buffer.h',
-  'suggestions/dzl-suggestion-entry.h',
-  'suggestions/dzl-suggestion-popover.h',
-  'suggestions/dzl-suggestion-row.h',
-  'suggestions/dzl-suggestion.h',
-
-  'theming/dzl-css-provider.h',
-  'theming/dzl-theme-manager.h',
-
-  'tree/dzl-tree-builder.h',
-  'tree/dzl-tree-node.h',
-  'tree/dzl-tree-types.h',
-  'tree/dzl-tree.h',
-
-  'util/dzl-cairo.h',
-  'util/dzl-counter.h',
-  'util/dzl-date-time.h',
-  'util/dzl-dnd.h',
-  'util/dzl-file-manager.h',
-  'util/dzl-heap.h',
-  'util/dzl-pango.h',
-  'util/dzl-rgba.h',
-
-  'widgets/dzl-bin.h',
-  'widgets/dzl-bolding-label.h',
-  'widgets/dzl-box.h',
-  'widgets/dzl-centering-bin.h',
-  'widgets/dzl-column-layout.h',
-  'widgets/dzl-elastic-bin.h',
-  'widgets/dzl-empty-state.h',
-  'widgets/dzl-entry-box.h',
-  'widgets/dzl-file-chooser-entry.h',
-  'widgets/dzl-list-box.h',
-  'widgets/dzl-multi-paned.h',
-  'widgets/dzl-pill-box.h',
-  'widgets/dzl-priority-box.h',
-  'widgets/dzl-progress-button.h',
-  'widgets/dzl-progress-menu-button.h',
-  'widgets/dzl-progress-icon.h',
-  'widgets/dzl-radio-box.h',
-  'widgets/dzl-scrolled-window.h',
-  'widgets/dzl-search-bar.h',
-  'widgets/dzl-simple-label.h',
-  'widgets/dzl-simple-popover.h',
-  'widgets/dzl-slider.h',
-  'widgets/dzl-stack-list.h',
-  'widgets/dzl-three-grid.h',
 ]
+
+subdir('actions')
+subdir('animation')
+subdir('app')
+subdir('bindings')
+subdir('cache')
+subdir('files')
+subdir('fuzzy')
+subdir('menus')
+subdir('panel')
+subdir('settings')
+subdir('shortcuts')
+subdir('statemachine')
+subdir('suggestions')
+subdir('theming')
+subdir('tree')
+subdir('util')
+subdir('widgets')
 
 libdazzle_public_sources = [
   'actions/dzl-child-property-action.c',
@@ -257,11 +167,9 @@ libdazzle_public_sources = [
 
 libdazzle_sources = [
   libdazzle_generated_headers,
-  libdazzle_public_headers,
   libdazzle_public_sources,
 
   'animation/dzl-frame-source.c',
-  'animation/dzl-frame-source.h',
 
   'fuzzy/dzl-fuzzy-index-private.h',
   'fuzzy/dzl-fuzzy-util.c',
@@ -272,17 +180,12 @@ libdazzle_sources = [
   'panel/dzl-tab-private.h',
 
   'shortcuts/dzl-shortcut-closure-chain.c',
-  'shortcuts/dzl-shortcut-closure-chain.h',
-  'shortcuts/dzl-shortcut-private.h',
-  'shortcuts/dzl-shortcuts-shortcut-private.h',
-  'shortcuts/dzl-shortcuts-window-private.h',
 
   'tree/dzl-tree-private.h',
 
   'util/dzl-util-private.h',
 
   'widgets/dzl-rect-helper.c',
-  'widgets/dzl-rect-helper.h',
 
   libdazzle_resources,
 ]
@@ -350,15 +253,15 @@ if get_option('with_introspection')
 endif
 
 # TODO: This is ugly and should be handled upstream
-foreach header: libdazzle_public_headers
-  header_split = header.split('/')
-  if header_split.length() == 2
-    header_path = join_paths(libdazzle_header_subdir, header_split[0])
-    install_headers(header, subdir: header_path)
-  else
-    install_headers(header, subdir: libdazzle_header_subdir)
-  endif
-endforeach
+#foreach header: libdazzle_public_headers
+#  header_split = header.split('/')
+#  if header_split.length() == 2
+#    header_path = join_paths(libdazzle_header_subdir, header_split[0])
+#    install_headers(header, subdir: header_path)
+#  else
+#    install_headers(header, subdir: libdazzle_header_subdir)
+#  endif
+#endforeach
 
 pkgg = import('pkgconfig')
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -332,7 +332,7 @@ if get_option('with_introspection')
                 install: true,
         install_dir_gir: girdir,
     install_dir_typelib: typelibdir,
-             extra_args: [ '--c-include=dazzle.h' ],
+             extra_args: [ '--c-include=dazzle.h', '--quiet' ],
   )
 
   if get_option('with_vapi')
@@ -369,4 +369,3 @@ pkgg.generate(
   description: 'Razzle Dazzle for Gtk+ 3.x applications',
      requires: 'gtk+-3.0',
 )
-

--- a/src/meson.build
+++ b/src/meson.build
@@ -304,11 +304,12 @@ libdazzle = shared_library(
   'dazzle-' + libdazzle_api_version,
   libdazzle_sources,
 
-  link_depends: 'dazzle.map',
-        c_args: libdazzle_args,
-     link_args: [ '-Wl,--version-script,' + join_paths(meson.current_source_dir(), 'dazzle.map') ],
-  dependencies: libdazzle_deps,
-       install: true,
+         link_depends: 'dazzle.map',
+               c_args: libdazzle_args,
+            link_args: [ '-Wl,--version-script,' + join_paths(meson.current_source_dir(), 'dazzle.map') ],
+         dependencies: libdazzle_deps,
+  include_directories: [ root_inc, src_inc ],
+              install: true,
 )
 
 libdazzle_dep = declare_dependency(

--- a/src/meson.build
+++ b/src/meson.build
@@ -81,6 +81,7 @@ libdazzle = shared_library(
   'dazzle-' + libdazzle_api_version,
   libdazzle_sources,
 
+            soversion: 0,
          link_depends: libdazzle_map,
                c_args: libdazzle_args,
             link_args: [ '-Wl,--version-script,' + libdazzle_map ],

--- a/src/meson.build
+++ b/src/meson.build
@@ -300,13 +300,15 @@ if get_option('enable_rdtscp')
   libdazzle_args += '-DDZL_HAVE_RDTSCP'
 endif
 
+libdazzle_map = join_paths(meson.current_source_dir(), 'dazzle.map')
+
 libdazzle = shared_library(
   'dazzle-' + libdazzle_api_version,
   libdazzle_sources,
 
-         link_depends: 'dazzle.map',
+         link_depends: libdazzle_map,
                c_args: libdazzle_args,
-            link_args: [ '-Wl,--version-script,' + join_paths(meson.current_source_dir(), 'dazzle.map') ],
+            link_args: [ '-Wl,--version-script,' + libdazzle_map ],
          dependencies: libdazzle_deps,
   include_directories: [ root_inc, src_inc ],
               install: true,

--- a/src/panel/meson.build
+++ b/src/panel/meson.build
@@ -17,6 +17,25 @@ panel_headers = [
   'dzl-tab.h',
 ]
 
+panel_sources = [
+  'dzl-dock-bin-edge.c',
+  'dzl-dock-bin.c',
+  'dzl-dock-item.c',
+  'dzl-dock-manager.c',
+  'dzl-dock-overlay-edge.c',
+  'dzl-dock-overlay.c',
+  'dzl-dock-paned.c',
+  'dzl-dock-revealer.c',
+  'dzl-dock-stack.c',
+  'dzl-dock-transient-grab.c',
+  'dzl-dock-widget.c',
+  'dzl-dock-window.c',
+  'dzl-dock.c',
+  'dzl-tab-strip.c',
+  'dzl-tab.c',
+]
+
 libdazzle_public_headers += files(panel_headers)
+libdazzle_public_sources += files(panel_sources)
 
 install_headers(panel_headers, subdir: join_paths(libdazzle_header_subdir, 'panel'))

--- a/src/panel/meson.build
+++ b/src/panel/meson.build
@@ -1,0 +1,22 @@
+panel_headers = [
+  'dzl-dock-bin-edge.h',
+  'dzl-dock-bin.h',
+  'dzl-dock-item.h',
+  'dzl-dock-manager.h',
+  'dzl-dock-overlay-edge.h',
+  'dzl-dock-overlay.h',
+  'dzl-dock-paned.h',
+  'dzl-dock-revealer.h',
+  'dzl-dock-stack.h',
+  'dzl-dock-transient-grab.h',
+  'dzl-dock-types.h',
+  'dzl-dock-widget.h',
+  'dzl-dock-window.h',
+  'dzl-dock.h',
+  'dzl-tab-strip.h',
+  'dzl-tab.h',
+]
+
+libdazzle_public_headers += files(panel_headers)
+
+install_headers(panel_headers, subdir: join_paths(libdazzle_header_subdir, 'panel'))

--- a/src/settings/meson.build
+++ b/src/settings/meson.build
@@ -1,0 +1,7 @@
+settings_headers = [
+  'dzl-settings-sandwich.h',
+]
+
+libdazzle_public_headers += files(settings_headers)
+
+install_headers(settings_headers, subdir: join_paths(libdazzle_header_subdir, 'settings'))

--- a/src/settings/meson.build
+++ b/src/settings/meson.build
@@ -2,6 +2,11 @@ settings_headers = [
   'dzl-settings-sandwich.h',
 ]
 
+settings_sources = [
+  'dzl-settings-sandwich.c',
+]
+
 libdazzle_public_headers += files(settings_headers)
+libdazzle_public_sources += files(settings_sources)
 
 install_headers(settings_headers, subdir: join_paths(libdazzle_header_subdir, 'settings'))

--- a/src/shortcuts/meson.build
+++ b/src/shortcuts/meson.build
@@ -1,0 +1,19 @@
+shortcuts_headers = [
+  'dzl-shortcut-accel-dialog.h',
+  'dzl-shortcut-chord.h',
+  'dzl-shortcut-context.h',
+  'dzl-shortcut-controller.h',
+  'dzl-shortcut-label.h',
+  'dzl-shortcut-manager.h',
+  'dzl-shortcut-model.h',
+  'dzl-shortcut-theme-editor.h',
+  'dzl-shortcut-theme.h',
+  'dzl-shortcuts-group.h',
+  'dzl-shortcuts-section.h',
+  'dzl-shortcuts-shortcut.h',
+  'dzl-shortcuts-window.h',
+]
+
+libdazzle_public_headers += files(shortcuts_headers)
+
+install_headers(shortcuts_headers, subdir: join_paths(libdazzle_header_subdir, 'shortcuts'))

--- a/src/shortcuts/meson.build
+++ b/src/shortcuts/meson.build
@@ -14,6 +14,26 @@ shortcuts_headers = [
   'dzl-shortcuts-window.h',
 ]
 
+shortcuts_sources = [
+  'dzl-shortcut-accel-dialog.c',
+  'dzl-shortcut-chord.c',
+  'dzl-shortcut-context.c',
+  'dzl-shortcut-controller.c',
+  'dzl-shortcut-label.c',
+  'dzl-shortcut-manager.c',
+  'dzl-shortcut-model.c',
+  'dzl-shortcut-theme-editor.c',
+  'dzl-shortcut-theme-load.c',
+  'dzl-shortcut-theme-save.c',
+  'dzl-shortcut-theme.c',
+  'dzl-shortcuts-group.c',
+  'dzl-shortcuts-section.c',
+  'dzl-shortcuts-shortcut.c',
+  'dzl-shortcuts-window.c',
+]
+
 libdazzle_public_headers += files(shortcuts_headers)
+libdazzle_public_sources += files(shortcuts_sources)
+libdazzle_private_sources += files('dzl-shortcut-closure-chain.c')
 
 install_headers(shortcuts_headers, subdir: join_paths(libdazzle_header_subdir, 'shortcuts'))

--- a/src/statemachine/meson.build
+++ b/src/statemachine/meson.build
@@ -1,0 +1,10 @@
+statemachine_headers = [
+  'dzl-state-machine-buildable.h',
+  'dzl-state-machine.h',
+]
+
+foreach h: statemachine_headers
+  libdazzle_public_headers += files(h)
+endforeach
+
+install_headers(statemachine_headers, subdir: join_paths(libdazzle_header_subdir, 'statemachine'))

--- a/src/statemachine/meson.build
+++ b/src/statemachine/meson.build
@@ -3,8 +3,12 @@ statemachine_headers = [
   'dzl-state-machine.h',
 ]
 
-foreach h: statemachine_headers
-  libdazzle_public_headers += files(h)
-endforeach
+statemachine_sources = [
+  'dzl-state-machine-buildable.c',
+  'dzl-state-machine.c',
+]
+
+libdazzle_public_headers += files(statemachine_headers)
+libdazzle_public_sources += files(statemachine_sources)
 
 install_headers(statemachine_headers, subdir: join_paths(libdazzle_header_subdir, 'statemachine'))

--- a/src/suggestions/meson.build
+++ b/src/suggestions/meson.build
@@ -1,0 +1,13 @@
+suggestions_headers = [
+  'dzl-suggestion-entry-buffer.h',
+  'dzl-suggestion-entry.h',
+  'dzl-suggestion-popover.h',
+  'dzl-suggestion-row.h',
+  'dzl-suggestion.h',
+]
+
+foreach h: suggestions_headers
+  libdazzle_public_headers += files(h)
+endforeach
+
+install_headers(suggestions_headers, subdir: join_paths(libdazzle_header_subdir, 'suggestions'))

--- a/src/suggestions/meson.build
+++ b/src/suggestions/meson.build
@@ -6,8 +6,15 @@ suggestions_headers = [
   'dzl-suggestion.h',
 ]
 
-foreach h: suggestions_headers
-  libdazzle_public_headers += files(h)
-endforeach
+suggestions_sources = [
+  'dzl-suggestion-entry-buffer.c',
+  'dzl-suggestion-entry.c',
+  'dzl-suggestion-popover.c',
+  'dzl-suggestion-row.c',
+  'dzl-suggestion.c',
+]
+
+libdazzle_public_headers += files(suggestions_headers)
+libdazzle_public_sources += files(suggestions_sources)
 
 install_headers(suggestions_headers, subdir: join_paths(libdazzle_header_subdir, 'suggestions'))

--- a/src/theming/meson.build
+++ b/src/theming/meson.build
@@ -1,0 +1,8 @@
+theming_headers = [
+  'dzl-css-provider.h',
+  'dzl-theme-manager.h',
+]
+
+libdazzle_public_headers += files(theming_headers)
+
+install_headers(theming_headers, subdir: join_paths(libdazzle_header_subdir, 'theming'))

--- a/src/theming/meson.build
+++ b/src/theming/meson.build
@@ -3,6 +3,12 @@ theming_headers = [
   'dzl-theme-manager.h',
 ]
 
+theming_sources = [
+  'dzl-css-provider.c',
+  'dzl-theme-manager.c',
+]
+
 libdazzle_public_headers += files(theming_headers)
+libdazzle_public_sources += files(theming_sources)
 
 install_headers(theming_headers, subdir: join_paths(libdazzle_header_subdir, 'theming'))

--- a/src/tree/meson.build
+++ b/src/tree/meson.build
@@ -5,6 +5,13 @@ tree_headers = [
   'dzl-tree.h',
 ]
 
+tree_sources = [
+  'dzl-tree-builder.c',
+  'dzl-tree.c',
+  'dzl-tree-node.c',
+]
+
 libdazzle_public_headers += files(tree_headers)
+libdazzle_public_sources += files(tree_sources)
 
 install_headers(tree_headers, subdir: join_paths(libdazzle_header_subdir, 'tree'))

--- a/src/tree/meson.build
+++ b/src/tree/meson.build
@@ -1,0 +1,10 @@
+tree_headers = [
+  'dzl-tree-builder.h',
+  'dzl-tree-node.h',
+  'dzl-tree-types.h',
+  'dzl-tree.h',
+]
+
+libdazzle_public_headers += files(tree_headers)
+
+install_headers(tree_headers, subdir: join_paths(libdazzle_header_subdir, 'tree'))

--- a/src/util/meson.build
+++ b/src/util/meson.build
@@ -1,0 +1,14 @@
+util_headers = [
+  'dzl-cairo.h',
+  'dzl-counter.h',
+  'dzl-date-time.h',
+  'dzl-dnd.h',
+  'dzl-file-manager.h',
+  'dzl-heap.h',
+  'dzl-pango.h',
+  'dzl-rgba.h',
+]
+
+libdazzle_public_headers += files(util_headers)
+
+install_headers(util_headers, subdir: join_paths(libdazzle_header_subdir, 'util'))

--- a/src/util/meson.build
+++ b/src/util/meson.build
@@ -9,6 +9,19 @@ util_headers = [
   'dzl-rgba.h',
 ]
 
+util_sources = [
+  'dzl-cairo.c',
+  'dzl-counter.c',
+  'dzl-date-time.c',
+  'dzl-dnd.c',
+  'dzl-file-manager.c',
+  'dzl-heap.c',
+  'dzl-pango.c',
+  'dzl-rgba.c',
+  'dzl-util.c',
+]
+
 libdazzle_public_headers += files(util_headers)
+libdazzle_public_sources += files(util_sources)
 
 install_headers(util_headers, subdir: join_paths(libdazzle_header_subdir, 'util'))

--- a/src/widgets/meson.build
+++ b/src/widgets/meson.build
@@ -1,0 +1,30 @@
+widgets_headers = [
+  'dzl-bin.h',
+  'dzl-bolding-label.h',
+  'dzl-box.h',
+  'dzl-centering-bin.h',
+  'dzl-column-layout.h',
+  'dzl-elastic-bin.h',
+  'dzl-empty-state.h',
+  'dzl-entry-box.h',
+  'dzl-file-chooser-entry.h',
+  'dzl-list-box.h',
+  'dzl-multi-paned.h',
+  'dzl-pill-box.h',
+  'dzl-priority-box.h',
+  'dzl-progress-button.h',
+  'dzl-progress-menu-button.h',
+  'dzl-progress-icon.h',
+  'dzl-radio-box.h',
+  'dzl-scrolled-window.h',
+  'dzl-search-bar.h',
+  'dzl-simple-label.h',
+  'dzl-simple-popover.h',
+  'dzl-slider.h',
+  'dzl-stack-list.h',
+  'dzl-three-grid.h',
+]
+
+libdazzle_public_headers += files(widgets_headers)
+
+install_headers(widgets_headers, subdir: join_paths(libdazzle_header_subdir, 'widgets'))

--- a/src/widgets/meson.build
+++ b/src/widgets/meson.build
@@ -25,6 +25,35 @@ widgets_headers = [
   'dzl-three-grid.h',
 ]
 
+widgets_sources = [
+  'dzl-bin.c',
+  'dzl-bolding-label.c',
+  'dzl-box.c',
+  'dzl-centering-bin.c',
+  'dzl-column-layout.c',
+  'dzl-elastic-bin.c',
+  'dzl-empty-state.c',
+  'dzl-entry-box.c',
+  'dzl-file-chooser-entry.c',
+  'dzl-list-box.c',
+  'dzl-multi-paned.c',
+  'dzl-pill-box.c',
+  'dzl-priority-box.c',
+  'dzl-progress-button.c',
+  'dzl-progress-menu-button.c',
+  'dzl-progress-icon.c',
+  'dzl-radio-box.c',
+  'dzl-scrolled-window.c',
+  'dzl-search-bar.c',
+  'dzl-simple-label.c',
+  'dzl-simple-popover.c',
+  'dzl-slider.c',
+  'dzl-stack-list.c',
+  'dzl-three-grid.c',
+]
+
 libdazzle_public_headers += files(widgets_headers)
+libdazzle_public_sources += files(widgets_sources)
+libdazzle_private_sources += files('dzl-rect-helper.c')
 
 install_headers(widgets_headers, subdir: join_paths(libdazzle_header_subdir, 'widgets'))


### PR DESCRIPTION
Instead of having a single array with all the files, keep the headers and sources listings inside each sub-directory, and merge everything in the top-level meson.build file.

This reduces the chances of leaving files behind, and increases the readability of the build. It also removes the hack with the split path when installing the headers.

Ideally, we could even create a static library for each module, and then use `link_whole_archive` into the shared library.