### PR TITLE
build: Enable C99 support in meson.build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project('libdazzle', 'c',
           version: '3.25.90',
           license: 'GPLv3+',
     meson_version: '>= 0.40.1',
-  default_options: [ 'warning_level=1', 'buildtype=debugoptimized' ],
+  default_options: [ 'warning_level=1', 'buildtype=debugoptimized', 'c_std=c99' ],
 )
 
 version_arr = meson.project_version().split('.')


### PR DESCRIPTION
We use C99 features (dzl-properties-group.c), so need to explicitly
enable them in meson.build, as some compilers will not enable them
automatically, and will instead error when they encounter usage of C99.

Signed-off-by: Philip Withnall <withnall@endlessm.com>