### PR TITLE
suggestions: Unset buffer's suggestion when entry is cleared

### DIFF
--- a/src/suggestions/dzl-suggestion-entry.c
+++ b/src/suggestions/dzl-suggestion-entry.c
@@ -242,6 +242,7 @@ dzl_suggestion_entry_changed (GtkEditable *editable)
 
   if (text == NULL || *text == '\0')
     {
+      dzl_suggestion_entry_buffer_set_suggestion (priv->buffer, NULL);
       g_signal_emit (self, signals [HIDE_SUGGESTIONS], 0);
       DZL_GOTO (finish);
     }


### PR DESCRIPTION
If there is no text in the entry, then it's not possible to provide a
sensible suggestion.

This might be a workaround for an Epiphany bug, but I think it makes sense to do anyway.