### PR TITLE
Vapi generation fix proposals for dzl-graph-view widget

### DIFF
--- a/src/Dazzle-1.0.metadata
+++ b/src/Dazzle-1.0.metadata
@@ -3,4 +3,5 @@ Dazzle name="Dazzle"
 *.*.cancellable#parameter nullable default=null
 *.*.io_priority default=GLib.Priority.LOW
 GraphModel.iter_set skip=false
+GraphModel.iter_get_value.value out
 

--- a/src/Dazzle-1.0.metadata
+++ b/src/Dazzle-1.0.metadata
@@ -2,4 +2,5 @@ Dazzle name="Dazzle"
 * cheader_filename="dazzle.h"
 *.*.cancellable#parameter nullable default=null
 *.*.io_priority default=GLib.Priority.LOW
+GraphModel.iter_set skip=false
 


### PR DESCRIPTION
Hi,

This 2-commits PR tries to solves two issues related to vapi generation which impact `dzl-graph-view` widget usage from a language outside C.

1. As explained in [Vala bindings documentation](https://wiki.gnome.org/Projects/Vala/Bindings#Variadic_Functions), variadic functions are declared non-introspectable inside gir file. It not prevents the usage of `dzl_graph_view_model_iter_set` function (https://github.com/chergert/libdazzle/blob/master/src/graphing/dzl-graph-model.c#L327), so the whole dazzling `dzl_graph_view` widget is just not usable from vapi generated bindings.

2. The other - smaller - issue prevents the usage of `dzl_graph_view_model_iter_get_value` function from outside C, because of the `value` parameter which isn't declared as `out`, so it's impossible to get the iter value for a given column. Adding the field `out` attribute made the trick. 

With the PR, it's now possible to use `dzl-graph-view` from - for exemple - vala : 

```vala

    var view = new Dazzle.GraphView();
    var column = new Dazzle.GraphColumn("column", typeof(int));
    var renderer = new Dazzle.GraphLineRenderer();
    renderer.column = 0;
    renderer.line_width = 1.0;
    renderer.stroke_color = "#ff0000";
    var model = new Dazzle.GraphModel();

    model.add_column(column);
    view.add_renderer(renderer);
    view.set_model(model);
    
    GLib.Timeout.add(1000, () => {
        Dazzle.GraphModelIter iter;
        model.push(out iter, get_monotonic_time());

        int inval = GLib.Random.int_range(0, 100);

        Dazzle.GraphModel.iter_set(iter, 0, inval, -1);

        Value outval = Dazzle.GraphModel.iter_get_value(iter, 0);

        return true;
    });
```
